### PR TITLE
feat(models): 新增 Claude Fable 5 模型选项

### DIFF
--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -260,6 +260,28 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
   ],
   claudeAgent: [
     {
+      slug: "claude-fable-5",
+      name: "Claude Fable 5",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High", isDefault: true },
+          { value: "xhigh", label: "Extra High" },
+          { value: "max", label: "Max" },
+          { value: "ultrathink", label: "Ultrathink" },
+          { value: "ultracode", label: "Ultracode" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: ["ultrathink"],
+        contextWindowOptions: [
+          { value: "200k", label: "200k", isDefault: true },
+          { value: "1m", label: "1M" },
+        ],
+      },
+    },
+    {
       slug: "claude-opus-4-8",
       name: "Claude Opus 4.8",
       capabilities: {
@@ -579,6 +601,9 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   claudeAgent: {
+    fable: "claude-fable-5",
+    "fable-5": "claude-fable-5",
+    "claude-fable5": "claude-fable-5",
     opus: "claude-opus-4-8",
     "opus-4.8": "claude-opus-4-8",
     "claude-opus-4.8": "claude-opus-4-8",


### PR DESCRIPTION
## 改动内容

在共享模型注册表(`packages/contracts/src/model.ts`)的 `claudeAgent` 提供商下新增 `claude-fable-5`,使其可以在模型选择器中被选中:

- 推理强度档位:low / medium / high(默认)/ xhigh / max,以及 ultrathink / ultracode
- 上下文窗口:200k(默认)/ 1M(选 1M 时按既有逻辑自动拼接 `[1m]` 后缀传给底层)
- `supportsFastMode: false`(Fast mode 目前仅 Opus 4.8/4.7/4.6 支持,Fable 5 不支持)
- 新增 `fable` / `fable-5` / `claude-fable5` 别名映射

## 验证

- `bun fmt` / `bun lint` / `bun typecheck` 全部通过(lint 0 错误,警告均为存量)
- `packages/shared/src/model.test.ts` 59 个测试全部通过
- 本地 dev 环境实测:模型下拉列表可正常选择 Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)