### PR TITLE
perf: reduce redundant tokens sent per turn for Codex and Claude providers

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -934,7 +934,7 @@ describe("sendTurn turn-param deduplication", () => {
       interactionMode: "default",
       effort: "medium",
     });
-    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    const params = sendRequest.mock.calls[0]![2] as Record<string, unknown>;
     expect(params).toHaveProperty("collaborationMode");
     expect(params).toHaveProperty("approvalPolicy", "never");
     expect(params).toHaveProperty("sandboxPolicy");
@@ -956,7 +956,7 @@ describe("sendTurn turn-param deduplication", () => {
       interactionMode: "default",
       effort: "medium",
     });
-    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    const params = sendRequest.mock.calls[0]![2] as Record<string, unknown>;
     expect(params).not.toHaveProperty("collaborationMode");
     expect(params).not.toHaveProperty("approvalPolicy");
     expect(params).not.toHaveProperty("sandboxPolicy");
@@ -978,7 +978,7 @@ describe("sendTurn turn-param deduplication", () => {
       interactionMode: "plan",
       effort: "medium",
     });
-    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    const params = sendRequest.mock.calls[0]![2] as Record<string, unknown>;
     expect(params).toHaveProperty("collaborationMode");
     const collab = params.collaborationMode as { mode: string };
     expect(collab.mode).toBe("plan");
@@ -1001,7 +1001,7 @@ describe("sendTurn turn-param deduplication", () => {
       interactionMode: "default",
       effort: "medium",
     });
-    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    const params = sendRequest.mock.calls[0]![2] as Record<string, unknown>;
     expect(params).toHaveProperty("approvalPolicy", "untrusted");
     expect(params).toHaveProperty("sandboxPolicy", { type: "readOnly" });
     expect(params).not.toHaveProperty("collaborationMode");

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -55,6 +55,7 @@ function createSendTurnHarness(runtimeMode: "approval-required" | "full-access" 
     collabReceiverTurns: new Map(),
     collabReceiverParents: new Map(),
     reviewTurnIds: new Set<string>(),
+    lastSentTurnParams: undefined,
   };
 
   const requireSession = vi
@@ -921,6 +922,89 @@ describe("sendTurn", () => {
         threadId: asThreadId("thread_1"),
       }),
     ).rejects.toThrow("Turn input must include text or attachments.");
+  });
+});
+
+describe("sendTurn turn-param deduplication", () => {
+  it("first turn (lastSentTurnParams undefined) sends collaborationMode, runtimeOverrides, model, and effort", async () => {
+    const { manager, sendRequest } = createSendTurnHarness("full-access");
+    await manager.sendTurn({
+      threadId: asThreadId("thread_1"),
+      input: "hello",
+      interactionMode: "default",
+      effort: "medium",
+    });
+    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    expect(params).toHaveProperty("collaborationMode");
+    expect(params).toHaveProperty("approvalPolicy", "never");
+    expect(params).toHaveProperty("sandboxPolicy");
+    expect(params).toHaveProperty("model");
+    expect(params).toHaveProperty("effort", "medium");
+  });
+
+  it("second turn with identical params omits collaborationMode, runtimeOverrides, model, and effort", async () => {
+    const { manager, context, sendRequest } = createSendTurnHarness("full-access");
+    (context as Record<string, unknown>).lastSentTurnParams = {
+      interactionMode: "default",
+      runtimeMode: "full-access",
+      model: "gpt-5.3-codex",
+      effort: "medium",
+    };
+    await manager.sendTurn({
+      threadId: asThreadId("thread_1"),
+      input: "follow-up",
+      interactionMode: "default",
+      effort: "medium",
+    });
+    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    expect(params).not.toHaveProperty("collaborationMode");
+    expect(params).not.toHaveProperty("approvalPolicy");
+    expect(params).not.toHaveProperty("sandboxPolicy");
+    expect(params).not.toHaveProperty("effort");
+    expect(params).not.toHaveProperty("model");
+  });
+
+  it("turn after interactionMode change re-sends collaborationMode", async () => {
+    const { manager, context, sendRequest } = createSendTurnHarness("full-access");
+    (context as Record<string, unknown>).lastSentTurnParams = {
+      interactionMode: "default",
+      runtimeMode: "full-access",
+      model: "gpt-5.3-codex",
+      effort: "medium",
+    };
+    await manager.sendTurn({
+      threadId: asThreadId("thread_1"),
+      input: "plan this",
+      interactionMode: "plan",
+      effort: "medium",
+    });
+    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    expect(params).toHaveProperty("collaborationMode");
+    const collab = params.collaborationMode as { mode: string };
+    expect(collab.mode).toBe("plan");
+    expect(params).not.toHaveProperty("approvalPolicy");
+    expect(params).not.toHaveProperty("sandboxPolicy");
+  });
+
+  it("turn after runtimeMode change re-sends approvalPolicy and sandboxPolicy", async () => {
+    const { manager, context, sendRequest } = createSendTurnHarness("full-access");
+    (context as Record<string, unknown>).lastSentTurnParams = {
+      interactionMode: "default",
+      runtimeMode: "full-access",
+      model: "gpt-5.3-codex",
+      effort: "medium",
+    };
+    (context.session as Record<string, unknown>).runtimeMode = "approval-required";
+    await manager.sendTurn({
+      threadId: asThreadId("thread_1"),
+      input: "next turn",
+      interactionMode: "default",
+      effort: "medium",
+    });
+    const params = sendRequest.mock.calls[0][2] as Record<string, unknown>;
+    expect(params).toHaveProperty("approvalPolicy", "untrusted");
+    expect(params).toHaveProperty("sandboxPolicy", { type: "readOnly" });
+    expect(params).not.toHaveProperty("collaborationMode");
   });
 });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -106,6 +106,14 @@ interface CodexSessionContext {
   nextRequestId: number;
   stopping: boolean;
   discovery?: boolean;
+  lastSentTurnParams: CodexLastSentTurnParams | undefined;
+}
+
+interface CodexLastSentTurnParams {
+  interactionMode: "default" | "plan" | undefined;
+  runtimeMode: RuntimeMode | undefined;
+  model: string | undefined;
+  effort: string | undefined;
 }
 
 interface CodexSkillListInput {
@@ -728,6 +736,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         reviewTurnIds: new Set(),
         nextRequestId: 1,
         stopping: false,
+        lastSentTurnParams: undefined,
       };
 
       this.sessions.set(threadId, context);
@@ -833,6 +842,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         threadOpenMethod = "thread/start";
         threadOpenResponse = await this.sendRequest(context, "thread/start", threadStartParams);
       }
+      context.lastSentTurnParams = undefined;
 
       const threadOpenRecord = this.readObject(threadOpenResponse);
       const threadIdRaw =
@@ -938,6 +948,20 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     if (!providerThreadId) {
       throw new Error("Session is missing provider resume thread id.");
     }
+    const normalizedModel = resolveCodexModelForAccount(
+      normalizeCodexModelSlug(input.model ?? context.session.model),
+      context.account,
+    );
+    const normalizedEffort = input.effort;
+    const interactionMode = input.interactionMode;
+
+    const last = context.lastSentTurnParams;
+    const isFirstTurn = last === undefined;
+    const runtimeModeChanged = isFirstTurn || last.runtimeMode !== context.session.runtimeMode;
+    const interactionModeChanged = isFirstTurn || last.interactionMode !== interactionMode;
+    const modelChanged = isFirstTurn || last.model !== normalizedModel;
+    const effortChanged = isFirstTurn || last.effort !== normalizedEffort;
+
     const turnStartParams: {
       threadId: string;
       input: Array<
@@ -962,34 +986,45 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     } = {
       threadId: providerThreadId,
       input: turnInput,
-      ...mapCodexRuntimeModeToTurnOverrides(context.session.runtimeMode),
     };
-    const normalizedModel = resolveCodexModelForAccount(
-      normalizeCodexModelSlug(input.model ?? context.session.model),
-      context.account,
-    );
-    if (normalizedModel) {
+
+    if (runtimeModeChanged) {
+      Object.assign(turnStartParams, mapCodexRuntimeModeToTurnOverrides(context.session.runtimeMode));
+    }
+
+    if (normalizedModel && modelChanged) {
       turnStartParams.model = normalizedModel;
     }
+
     if (input.serviceTier !== undefined) {
       turnStartParams.serviceTier = input.serviceTier;
     }
-    if (input.effort) {
-      turnStartParams.effort = input.effort;
+
+    if (normalizedEffort && effortChanged) {
+      turnStartParams.effort = normalizedEffort;
     }
-    const collaborationMode = buildCodexCollaborationMode({
-      ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
-      ...(normalizedModel !== undefined ? { model: normalizedModel } : {}),
-      ...(input.effort !== undefined ? { effort: input.effort } : {}),
-    });
-    if (collaborationMode) {
-      if (!turnStartParams.model) {
-        turnStartParams.model = collaborationMode.settings.model;
+
+    if (interactionModeChanged) {
+      const collaborationMode = buildCodexCollaborationMode({
+        ...(interactionMode !== undefined ? { interactionMode } : {}),
+        ...(normalizedModel !== undefined ? { model: normalizedModel } : {}),
+        ...(normalizedEffort !== undefined ? { effort: normalizedEffort } : {}),
+      });
+      if (collaborationMode) {
+        if (!turnStartParams.model) {
+          turnStartParams.model = collaborationMode.settings.model;
+        }
+        turnStartParams.collaborationMode = collaborationMode;
       }
-      turnStartParams.collaborationMode = collaborationMode;
     }
 
     const response = await this.sendRequest(context, "turn/start", turnStartParams);
+    context.lastSentTurnParams = {
+      interactionMode,
+      runtimeMode: context.session.runtimeMode,
+      model: normalizedModel,
+      effort: normalizedEffort,
+    };
     const turnIdRaw = this.readString(this.readObject(this.readObject(response), "turn"), "id");
     if (!turnIdRaw) {
       throw new Error("turn/start response did not include a turn id.");
@@ -1346,6 +1381,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         reviewTurnIds: new Set(),
         nextRequestId: 1,
         stopping: false,
+        lastSentTurnParams: undefined,
       };
 
       this.sessions.set(threadId, context);
@@ -1915,6 +1951,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       nextRequestId: 1,
       stopping: false,
       discovery: true,
+      lastSentTurnParams: undefined,
     };
 
     this.discoverySessions.set(normalizedCwd, context);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -286,7 +286,7 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
-      assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.deepEqual(createInput?.options.settingSources, ["user", "project"]);
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
     }).pipe(
@@ -306,7 +306,7 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
-      assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.deepEqual(createInput?.options.settingSources, ["user", "project"]);
       assert.equal(createInput?.options.permissionMode, undefined);
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
       assert.deepEqual(createInput?.options.systemPrompt, {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -199,6 +199,7 @@ interface ClaudeSessionContext {
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
+  lastSentPermissionMode: PermissionMode | undefined;
   currentApiModelId: string | undefined;
   resumeSessionId: string | undefined;
   readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
@@ -730,10 +731,7 @@ const SUPPORTED_CLAUDE_IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/webp",
 ]);
-const CLAUDE_SETTING_SOURCES = [
-  "user",
-  "project",
-] as const satisfies ReadonlyArray<SettingSource>;
+const CLAUDE_SETTING_SOURCES = ["user", "project"] as const satisfies ReadonlyArray<SettingSource>;
 const EMBEDDED_CLAUDE_SYSTEM_PROMPT_APPEND = [
   "You are running inside Peak Code, a coding app that embeds the Claude Agent SDK.",
   "Do not present the host app as Claude Code unless the user is explicitly asking about Claude Code.",
@@ -3317,6 +3315,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           streamFiber: undefined,
           startedAt,
           basePermissionMode: permissionMode,
+          lastSentPermissionMode: undefined,
           currentApiModelId: apiModelId,
           resumeSessionId: sessionId,
           pendingApprovals,
@@ -3432,16 +3431,22 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         // "plan" maps directly to the SDK's "plan" permission mode;
         // "default" restores the session's original permission mode.
         // When interactionMode is absent we leave the current mode unchanged.
-        if (input.interactionMode === "plan") {
-          yield* Effect.tryPromise({
-            try: () => context.query.setPermissionMode("plan"),
-            catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
-          });
-        } else if (input.interactionMode === "default") {
-          yield* Effect.tryPromise({
-            try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
-            catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
-          });
+        const targetPermissionMode: PermissionMode =
+          input.interactionMode === "plan"
+            ? "plan"
+            : (context.basePermissionMode ?? "default");
+
+        if (
+          input.interactionMode === "plan" ||
+          input.interactionMode === "default"
+        ) {
+          if (context.lastSentPermissionMode !== targetPermissionMode) {
+            yield* Effect.tryPromise({
+              try: () => context.query.setPermissionMode(targetPermissionMode),
+              catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+            });
+            context.lastSentPermissionMode = targetPermissionMode;
+          }
         }
 
         const turnId = TurnId.makeUnsafe(yield* Random.nextUUIDv4);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -733,7 +733,6 @@ const SUPPORTED_CLAUDE_IMAGE_MIME_TYPES = new Set([
 const CLAUDE_SETTING_SOURCES = [
   "user",
   "project",
-  "local",
 ] as const satisfies ReadonlyArray<SettingSource>;
 const EMBEDDED_CLAUDE_SYSTEM_PROMPT_APPEND = [
   "You are running inside Peak Code, a coding app that embeds the Claude Agent SDK.",


### PR DESCRIPTION
## Summary

- **P0-4**: Remove `"local"` from `CLAUDE_SETTING_SOURCES` so Claude sessions no longer load `CLAUDE.local.md` on every session start
- **P0-3**: Skip `setPermissionMode` call when the permission mode hasn't changed between turns (unnecessary SDK round-trip per turn)
- **P0-1 / P1 / P2**: Add `lastSentTurnParams` diff mechanism to `CodexAppServerManager` — `collaborationMode` (developer_instructions), `approvalPolicy`/`sandboxPolicy`, `model`, and `effort` are only sent when they change or on the first turn after a thread open

## Background

Codex app-server persists `collaborationMode`, `approvalPolicy`, `sandboxPolicy`, `model`, and `effort` across turns on the same thread. PeakCode was re-sending all of these on every `turn/start`, wasting tokens each turn.

Root cause: `interactionMode` and `runtimeMode` in `ThreadTurnStartRequestedPayload` have `Schema.withDecodingDefault`, so they are never `undefined` — all conditional "only send if changed" guards were dead code.

## Token savings per turn

| Field | Default mode | Plan mode |
|---|---|---|
| `collaborationMode` / `developer_instructions` | ~504 tokens | ~2,255 tokens |
| `approvalPolicy` + `sandboxPolicy` | ~19 tokens | ~19 tokens |
| `model` + `effort` | ~10 tokens | ~10 tokens |

## Changes

- `apps/server/src/codexAppServerManager.ts` — `CodexLastSentTurnParams` type + `lastSentTurnParams` field on context; reset on `thread/start` / `thread/resume`; diff in `sendTurn`
- `apps/server/src/codexAppServerManager.test.ts` — 4 new deduplication tests
- `apps/server/src/provider/Layers/ClaudeAdapter.ts` — `lastSentPermissionMode` field on context; conditional `setPermissionMode`; remove `"local"` from `CLAUDE_SETTING_SOURCES`
- `apps/server/src/provider/Layers/ClaudeAdapter.test.ts` — update 2 test assertions for new `settingSources` value

## Test plan

- [ ] First turn after thread open sends all fields (collaborationMode, approvalPolicy, sandboxPolicy, model, effort)
- [ ] Subsequent turns with unchanged params omit all deduped fields
- [ ] `interactionMode` change re-sends `collaborationMode` with correct mode
- [ ] `runtimeMode` change re-sends `approvalPolicy` / `sandboxPolicy`
- [ ] `bun fmt && bun lint && bun typecheck` all pass