### PR TITLE
fix(gateway): tolerate malformed SSE chunks and fix Anthropic tool bl…

### DIFF
--- a/apps/server/src/anthropicAdapter.ts
+++ b/apps/server/src/anthropicAdapter.ts
@@ -381,7 +381,6 @@ export function openAIChatStreamToAnthropicStream(
 
       const reader = upstream.getReader();
       let buffer = "";
-      let nextBlockIndex = 0;
       let textBlockOpen = false;
       let textBlockStarted = false;
       let finalStopReason = "end_turn";
@@ -480,12 +479,16 @@ export function openAIChatStreamToAnthropicStream(
           }
         }
 
-        // Flush: close text block, then emit tool_use blocks.
+        // Flush: close text block, then emit tool_use blocks. Tool blocks
+        // follow the text block sequentially so their indices are contiguous
+        // (text=0, tool1=1, tool2=2, …) — Claude Code uses `index` to match
+        // content_block_start/delta/stop events, so collisions break tool calls.
         closeTextBlock();
+        let toolBlockIndex = textBlockStarted ? 1 : 0;
         for (const [idx, tc] of [...toolCallsByIndex.entries()].sort((a, b) => a[0] - b[0])) {
           if (emittedToolStarts.has(idx)) continue;
           emittedToolStarts.add(idx);
-          const blockIndex = textBlockStarted ? nextBlockIndex + 1 : nextBlockIndex;
+          const blockIndex = toolBlockIndex++;
           // Anthropic streaming tool_use protocol:
           // 1. content_block_start with EMPTY input ({}) — Claude Code expects
           //    input to arrive via input_json_delta, not in the start event.
@@ -505,7 +508,6 @@ export function openAIChatStreamToAnthropicStream(
             type: "content_block_stop",
             index: blockIndex,
           });
-          nextBlockIndex = blockIndex;
         }
 
         enqueue("message_delta", {

--- a/apps/server/src/gateway.ts
+++ b/apps/server/src/gateway.ts
@@ -425,7 +425,12 @@ export function chatStreamToResponsesStream(
               .map((line) => line.slice(5).trim())
               .join("\n");
             if (!data || data === "[DONE]") continue;
-            const chunk = JSON.parse(data) as unknown;
+            let chunk: unknown;
+            try {
+              chunk = JSON.parse(data);
+            } catch {
+              continue;
+            }
             if (!isRecord(chunk) || !Array.isArray(chunk.choices)) continue;
             for (const choice of chunk.choices) {
               if (!isRecord(choice) || !isRecord(choice.delta)) continue;


### PR DESCRIPTION
…ock indices

- gateway.ts: wrap SSE JSON.parse in try/catch so a single malformed chunk from the upstream no longer aborts the entire stream (matches mimoAdapter and anthropicAdapter behavior).
- anthropicAdapter.ts: assign sequential content_block indices when emitting multiple tool_use blocks in the streaming response. Previously every tool call reused the same index because nextBlockIndex was never incremented, which caused the Claude SDK to drop all but the first tool call.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
