### PR TITLE
feat(provider): support updating project dependencies in web UI

### DIFF
--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -18,7 +18,12 @@ import { ProviderHealth } from "../Services/ProviderHealth";
 const encoder = new TextEncoder();
 
 function makeTempAgentDir(prefix = "t3-test-pi-agent-") {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.writeFileSync(
+    path.join(dir, "auth.json"),
+    JSON.stringify({ anthropic: { type: "api_key", key: "test" } }),
+  );
+  return dir;
 }
 
 function mockHandle(result: { stdout: string; stderr: string; code: number }) {
@@ -138,7 +143,8 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
     const spawnerLayer = mockSpawnerLayer((args) => {
       const joined = args.join(" ");
       if (joined === "--version") return { stdout: "pi 0.130.0\n", stderr: "", code: 0 };
-      if (joined === "update") return { stdout: "Updated to 0.131.0\n", stderr: "", code: 0 };
+      if (joined === "update" || joined.startsWith("update"))
+        return { stdout: "Updated to 0.131.0\n", stderr: "", code: 0 };
       throw new Error(`Unexpected args: ${joined}`);
     });
     return ProviderHealthLive.pipe(

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -72,6 +72,9 @@ const UPDATE_TIMEOUT_MS = 5 * 60_000;
 
 function isPiNativeCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
+  if (normalized.includes("/node_modules/")) {
+    return false;
+  }
   return (
     normalized.endsWith("/.pi/") || normalized.includes("/.pi/bin/pi") || normalized.endsWith("/pi")
   );
@@ -90,6 +93,7 @@ const PACKAGE_MANAGED_PROVIDER_UPDATES: Partial<
       args: () => ["update"],
       lockKey: "pi-native",
       strategy: "always",
+      excludedInstallSources: ["project"],
       isCommandPath: isPiNativeCommandPath,
     },
   },
@@ -523,9 +527,11 @@ export const ProviderHealthLive = Layer.effect(
     const runUpdateCommand = Effect.fn("runProviderUpdateCommand")(function* (input: {
       readonly command: string;
       readonly args: ReadonlyArray<string>;
+      readonly cwd?: string | undefined;
     }) {
       const child = yield* spawner.spawn(
         ChildProcess.make(input.command, [...input.args], {
+          cwd: input.cwd,
           shell: process.platform === "win32",
           env: process.env,
         }),
@@ -589,6 +595,7 @@ export const ProviderHealthLive = Layer.effect(
         const commandResult = yield* runUpdateCommand({
           command: update.executable,
           args: update.args,
+          cwd: update.cwd,
         }).pipe(
           Effect.scoped,
           Effect.timeoutOption(Duration.millis(UPDATE_TIMEOUT_MS)),
@@ -632,15 +639,19 @@ export const ProviderHealthLive = Layer.effect(
         const providers = yield* refreshNow.pipe(Effect.mapError(toUpdateError));
         const refreshed = providers.find((status) => status.provider === provider);
         const stillOutdated = refreshed?.versionAdvisory?.status === "behind_latest";
+        const isProjectDeps = update.lockKey === "project-dependencies";
         const finalProviders = yield* setProviderUpdateState(
           provider,
           makeUpdateState({
-            status: stillOutdated ? "unchanged" : "succeeded",
+            status: stillOutdated && !isProjectDeps ? "unchanged" : "succeeded",
             startedAt,
             finishedAt,
-            message: stillOutdated
-              ? "Update command completed, but Peak Code still detects an outdated provider version."
-              : "Provider updated.",
+            message:
+              stillOutdated && !isProjectDeps
+                ? "Update command completed, but Peak Code still detects an outdated provider version."
+                : isProjectDeps
+                  ? "Project dependencies updated."
+                  : "Provider updated.",
             output: output ? output.slice(0, UPDATE_OUTPUT_MAX_BYTES) : null,
           }),
         );

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -111,6 +111,27 @@ describe("providerMaintenance", () => {
     });
   });
 
+  it("resolves bun update for project node_modules binaries", () => {
+    const capabilities = resolvePackageManagedProviderMaintenance(PI_NATIVE_DEFINITION, {
+      binaryPath: "pi",
+      realCommandPath: "/Users/test/workspace/PeakCode/apps/server/node_modules/.bin/pi",
+    });
+
+    assert.deepStrictEqual(capabilities.update, {
+      command:
+        "bun update @earendil-works/pi-coding-agent @earendil-works/pi-ai @earendil-works/pi-agent-core",
+      executable: "bun",
+      args: [
+        "update",
+        "@earendil-works/pi-coding-agent",
+        "@earendil-works/pi-ai",
+        "@earendil-works/pi-agent-core",
+      ],
+      lockKey: "project-dependencies",
+      cwd: "/Users/test/workspace/PeakCode/apps/server",
+    });
+  });
+
   it("marks older semver versions as behind latest", () => {
     const advisory = createProviderVersionAdvisory({
       provider: "pi",

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -12,7 +12,7 @@ const LATEST_VERSION_TIMEOUT_MS = 4_000;
 const PROVIDER_UPDATE_ACTION_MESSAGE = "Install the update now or review provider settings.";
 const WINDOWS_EXECUTABLE_EXTENSIONS = ["", ".exe", ".cmd", ".bat"] as const;
 
-type ProviderInstallSource = "npm" | "bun" | "pnpm" | "homebrew" | "native" | "unknown";
+type ProviderInstallSource = "npm" | "bun" | "pnpm" | "homebrew" | "native" | "project" | "unknown";
 
 interface ParsedSemver {
   readonly major: number;
@@ -39,6 +39,7 @@ export interface ProviderMaintenanceCommandAction {
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly lockKey: string;
+  readonly cwd?: string | undefined;
 }
 
 export interface ProviderMaintenanceCapabilityResolutionOptions {
@@ -198,10 +199,11 @@ function hasPathSeparator(value: string): boolean {
 export function makeProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderKind;
   readonly packageName: string | null;
-  readonly latestVersionSource?: ProviderLatestVersionSource | null;
+  readonly latestVersionSource?: ProviderLatestVersionSource | null | undefined;
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
+  readonly updateCwd?: string | null | undefined;
 }): ProviderMaintenanceCapabilities {
   const update =
     input.updateExecutable === null || input.updateLockKey === null
@@ -211,6 +213,7 @@ export function makeProviderMaintenanceCapabilities(input: {
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
+          ...(input.updateCwd ? { cwd: input.updateCwd } : {}),
         };
   return {
     provider: input.provider,
@@ -329,6 +332,9 @@ function detectInstallSource(
   definition: PackageManagedProviderMaintenanceDefinition,
   commandPath: string,
 ): ProviderInstallSource {
+  if (isProjectNodeModulesCommandPath(commandPath)) {
+    return "project";
+  }
   if (definition.nativeUpdate?.isCommandPath?.(commandPath)) {
     return "native";
   }
@@ -347,12 +353,49 @@ function detectInstallSource(
   return "unknown";
 }
 
+function extractProjectDirectory(commandPath: string): string | undefined {
+  const normalized = normalizeCommandPath(commandPath);
+  const index = normalized.indexOf("/node_modules");
+  if (index !== -1) {
+    return commandPath.slice(0, index);
+  }
+  return undefined;
+}
+
+function makeProjectDependencyProviderMaintenanceCapabilities(input: {
+  readonly definition: PackageManagedProviderMaintenanceDefinition;
+  readonly commandPath?: string | undefined;
+}): ProviderMaintenanceCapabilities {
+  const { definition, commandPath } = input;
+  const projectDir = commandPath ? extractProjectDirectory(commandPath) : undefined;
+  const packages =
+    definition.provider === "pi"
+      ? [definition.npmPackageName, "@earendil-works/pi-ai", "@earendil-works/pi-agent-core"]
+      : [definition.npmPackageName];
+
+  return makeProviderMaintenanceCapabilities({
+    provider: definition.provider,
+    packageName: definition.npmPackageName,
+    updateExecutable: "bun",
+    updateArgs: ["update", ...packages],
+    updateLockKey: "project-dependencies",
+    updateCwd: projectDir,
+  });
+}
+
 function makeProviderMaintenanceForInstallSource(input: {
   readonly definition: PackageManagedProviderMaintenanceDefinition;
   readonly installSource: ProviderInstallSource;
-  readonly executable?: string | null;
+  readonly executable?: string | null | undefined;
+  readonly commandPath?: string | undefined;
 }): ProviderMaintenanceCapabilities {
-  const { definition, installSource, executable } = input;
+  const { definition, installSource, executable, commandPath } = input;
+  if (installSource === "project") {
+    return makeProjectDependencyProviderMaintenanceCapabilities({
+      definition,
+      commandPath,
+    });
+  }
   if (
     definition.nativeUpdate?.strategy === "always" &&
     !definition.nativeUpdate.excludedInstallSources?.includes(installSource)
@@ -392,6 +435,18 @@ function makeProviderMaintenanceForInstallSource(input: {
   });
 }
 
+function isProjectNodeModulesCommandPath(commandPath: string): boolean {
+  const normalized = normalizeCommandPath(commandPath);
+  return (
+    (normalized.includes("/node_modules/.bin/") || normalized.includes("/node_modules/")) &&
+    !isBunGlobalCommandPath(normalized) &&
+    !isPnpmGlobalCommandPath(normalized) &&
+    !normalized.includes("/.npm-global/") &&
+    !normalized.startsWith("/usr/local/") &&
+    !normalized.startsWith("/opt/homebrew/")
+  );
+}
+
 function isBunGlobalCommandPath(commandPath: string): boolean {
   return normalizeCommandPath(commandPath).includes("/.bun/bin/");
 }
@@ -410,7 +465,7 @@ function isPnpmGlobalCommandPath(commandPath: string): boolean {
 function isNpmGlobalCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
   return (
-    normalized.includes("/node_modules/.bin/") ||
+    normalized.includes("/.npm-global/") ||
     normalized.includes("/lib/node_modules/") ||
     normalized.includes("/npm/node_modules/")
   );
@@ -452,6 +507,7 @@ export function resolvePackageManagedProviderMaintenance(
         definition,
         installSource,
         executable: binaryPath,
+        commandPath,
       });
     }
   }


### PR DESCRIPTION
### Summary

When a provider binary (such as `pi`) is installed as a project local dependency inside `node_modules/.bin/` instead of globally, running provider self-update commands (e.g. `pi update`) fails with `pi cannot self-update this installation`.

This PR detects project-local dependency installations and delegates the update action to the project package manager (`bun update`) in the project directory, allowing one-click dependency updates from the Web UI.

### Changes
- **Source Detection**: In `providerMaintenance.ts`, identify binaries under project `node_modules/.bin/` as `installSource: "project"`.
- **Command Generation**: For project dependencies, construct `bun update <packages>` with the resolved project working directory (`cwd`).
- **Update Execution**: In `ProviderHealth.ts`, pass `cwd` to `runUpdateCommand`, exclude `project` from native self-update commands, and report `Project dependencies updated.` upon completion.
- **Tests**: Added unit test in `providerMaintenance.test.ts` verifying project dependency resolution, and updated `ProviderHealth.test.ts`.